### PR TITLE
:bug: Throw error message if course list ist empty.

### DIFF
--- a/util/interaction.py
+++ b/util/interaction.py
@@ -14,6 +14,18 @@ def input_choices_from_list(choices, text):
         a list of indices chosen by the user
     """
 
+    if not choices:
+        noCourses_text = """
+            There is an authorization problem.
+            It seems, that no managing role is assigned to your Moodle account.
+            Please check your Moodle instance for valid role assignment
+
+            exiting now...
+        """
+        print(noCourses_text)
+        import sys
+        sys.exit()
+
     digits = str(math.ceil(math.log10(len(choices))))
     format_str = '{:' + digits + 'd} {}'
     for n, c in enumerate(choices, 0):


### PR DESCRIPTION
If course list is empty following math domain error is thrown:

```
onoz…
math domain error
Traceback (most recent call last):
  File "./mdt.py", line 82, in <module>
    main()
  File "./mdt.py", line 68, in main
    func(**kwargs)
  File "/home/user/Programing/Projects/mdt/moodle-destroyer-tools/frontend/commands.py", line 117, in init
    choices = interaction.input_choices_from_list(courses, '\n  choose courses, seperate with space: ')
  File "/home/user/Programing/Projects/mdt/moodle-destroyer-tools/util/interaction.py", line 17, in input_choices_from_list
    digits = str(math.ceil(math.log10(len(choices))))
```

In order to avoid `math.log10(0)` and therefore a math domain exception, the length of **choices** must not be zero.